### PR TITLE
Fix background_image for pandas

### DIFF
--- a/twint/storage/panda.py
+++ b/twint/storage/panda.py
@@ -107,6 +107,10 @@ def update(object, config):
         _object_blocks[_type].append(_data)
     elif _type == "user":
         user = object
+        try:
+            background_image = user.background_image
+        except:
+            background_image = ""
         _data = {
             "id": user.id,
             "name": user.name,
@@ -125,7 +129,7 @@ def update(object, config):
             "private": user.is_private,
             "verified": user.is_verified,
             "avatar": user.avatar,
-            "background_image": user.background_image,
+            "background_image": background_image,
             }
         _object_blocks[_type].append(_data)
     elif _type == "followers" or _type == "following":


### PR DESCRIPTION
I use twint with pandas and since twitter made the changes that affected this great project the background_image is no longer collectable.

When I run 
```
import twint

c = twint.Config()
c.Username = 'kennbroorg'
c.Pandas = True
c.User_full = True
twint.run.Lookup(c)
```
The output was :
```
CRITICAL:root:twint.get:User:'user' object has no attribute 'background_image'
```
With this change the output is
```
1024765653620682754 | kennbro | @kennbroorg | Private: 0 | Verified: 0 | Bio:  | Location:  | Url: https://twitter.com/kennbroorg | Joined:   | Tweets: 591 | Following: 159 | Followers: 531 | Likes:  | Media:  | Avatar: https://pbs.twimg.com/profile_images/1073005218504294400/jnQD0hx5_normal.jpg
```