### PR TITLE
Fix BulkIndexError and time parsing when using Elasticsearch

### DIFF
--- a/twint/output.py
+++ b/twint/output.py
@@ -185,8 +185,8 @@ async def Users(u, config, conn):
         logme.debug(__name__ + ':User:Elasticsearch')
         _save_date = user.join_date
         _save_time = user.join_time
-        user.join_date = str(datetime.strptime(user.join_date, "%d %b %Y")).split()[0]
-        user.join_time = str(datetime.strptime(user.join_time, "%I:%M %p")).split()[1]
+        user.join_date = str(datetime.strptime(user.join_date, "%Y-%m-%d")).split()[0]
+        user.join_time = str(datetime.strptime(user.join_time, "%H:%M:%S %Z")).split()[1]
         elasticsearch.UserProfile(user, config)
         user.join_date = _save_date
         user.join_time = _save_time

--- a/twint/storage/elasticsearch.py
+++ b/twint/storage/elasticsearch.py
@@ -342,8 +342,8 @@ def UserProfile(user, config):
                 "followers": user.followers,
                 "likes": user.likes,
                 "media": user.media_count,
-                "private": user.is_private,
-                "verified": user.is_verified,
+                "private": int(user.is_private),
+                "verified": int(user.is_verified),
                 "avatar": user.avatar,
                 "background_image": user.background_image,
                 "session": config.Essid


### PR DESCRIPTION
Twitter has changed the time data format, so with the following code
```
config = twint.Config()
config.Username = 'twitter'
config.Elasticsearch = 'localhost:9200'
twint.run.Lookup(config)
```
I was getting the `ValueError`
```
CRITICAL:root:twint.get:User:time data '2007-02-20' does not match format '%d %b %Y'
ERROR:root:twint.run:Twint:Lookup:Unexpected exception occurred.
Traceback (most recent call last):
  File "/home/dikuchan/.local/share/virtualenvs/twittify-wL50o2cO/src/twint/twint/run.py", line 307, in Lookup
    await get.User(self.config.Username, self.config, db.Conn(self.config.Database))
  File "/home/dikuchan/.local/share/virtualenvs/twittify-wL50o2cO/src/twint/twint/get.py", line 228, in User
    await Users(j_r, config, conn)
  File "/home/dikuchan/.local/share/virtualenvs/twittify-wL50o2cO/src/twint/twint/output.py", line 188, in Users
    user.join_date = str(datetime.strptime(user.join_date, "%d %b %Y")).split()[0]
  File "/usr/lib/python3.8/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/usr/lib/python3.8/_strptime.py", line 349, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data '2007-02-20' does not match format '%d %b %Y'
```

This problem was fixed by replacing the format parameters in datetime.

Also, boolean fields `private` and `verified` could not be parsed correctly, which is referenced in #1058. They are now replaced with integers.