### PR TITLE
modify py-googletrans package

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Twitter limits scrolls while browsing the user timeline. This means that with `.
 - schedule;
 - geopy;
 - fake-useragent;
-- py-googletransx.
+- py-googletrans.
 
 ## Installing
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ VERSION = None
 REQUIRED = [
     'aiohttp', 'aiodns', 'beautifulsoup4', 'cchardet', 'dataclasses',
     'elasticsearch', 'pysocks', 'pandas', 'aiohttp_socks',
-    'schedule', 'geopy', 'fake-useragent', 'googletransx'
+    'schedule', 'geopy', 'fake-useragent', 'googletrans'
 ]
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/twint/tweet.py
+++ b/twint/tweet.py
@@ -2,7 +2,7 @@ from time import strftime, localtime
 from datetime import datetime, timezone
 
 import logging as logme
-from googletransx import Translator
+from googletrans import Translator
 # ref. 
 # - https://github.com/x0rzkov/py-googletrans#basic-usage
 translator = Translator()


### PR DESCRIPTION
### modify py-googletrans package,fix googletrans error;
twint use 'py-googletransx' package,but is not update.
So i modify this package version
#### in my mac
   m1,Big sur:
  throw  erro: AttributeError: 'NoneType' object has no attribute 'group' ;

