### PR TITLE
Only require dataclasses if on python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 from setuptools import setup
 import io
 import os
+import sys
 
 # Package meta-data
 NAME = 'twint'
@@ -14,10 +15,12 @@ VERSION = None
 
 # Packages required
 REQUIRED = [
-    'aiohttp', 'aiodns', 'beautifulsoup4', 'cchardet', 'dataclasses',
+    'aiohttp', 'aiodns', 'beautifulsoup4', 'cchardet',
     'elasticsearch', 'pysocks', 'pandas', 'aiohttp_socks',
     'schedule', 'geopy', 'fake-useragent', 'googletransx'
 ]
+if sys.version_info.major >= 3 and sys.version_info.minor < 7:
+    REQUIRED.append("dataclasses")
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
When attempting to use twint on a python 3.9 system, I received the following issue after using `@dataclass` in my own code:

`AttributeError: module 'typing' has no attribute '_ClassVar'`

This was the result of doing something like this in a dataclass:

`translated_content: typing.Optional[str]`

I believe this is because the `dataclasses` dependency in twint is conflicting with the typing module on python 3.9, so this just installs `dataclasses` if the python version is 3.6, since it is included on 3.7+ natively.