### PR TITLE
Updated url.py limit param

### DIFF
--- a/twint/url.py
+++ b/twint/url.py
@@ -67,7 +67,7 @@ async def MobileProfile(username, init):
 async def Search(config, init):
     logme.debug(__name__ + ':Search')
     url = base
-    tweet_count = 100
+    tweet_count = 100 if not config.Limit else config.Limit
     q = ""
     params = [
         # ('include_blocking', '1'),


### PR DESCRIPTION
Previous limit param on Search feature was set to 100 by default. This made it retrieve inconsistent tweet scraping especially when used with another API that specifies the limit.