### PR TITLE
Requirements: Fixed aiohttp version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp
+aiohttp==3.7.0
 aiodns
 beautifulsoup4
 cchardet


### PR DESCRIPTION
Fix https://github.com/twintproject/twint/issues/1297

After some upgrades on aiohttp, aiohttop_socks doesnt work.