### PR TITLE
Fix empty tweet search results and limit of 20 tweets returned

### DIFF
--- a/twint/url.py
+++ b/twint/url.py
@@ -67,7 +67,7 @@ async def MobileProfile(username, init):
 async def Search(config, init):
     logme.debug(__name__ + ':Search')
     url = base
-    tweet_count = 100
+    tweet_count = 100 if not config.Limit else config.Limit
     q = ""
     params = [
         # ('include_blocking', '1'),

--- a/twint/url.py
+++ b/twint/url.py
@@ -89,7 +89,7 @@ async def Search(config, init):
         ('send_error_codes', 'true'),
         ('simple_quoted_tweet', 'true'),
         ('count', tweet_count),
-        # ('query_source', 'typed_query'),
+        ('query_source', 'typed_query'),
         # ('pc', '1'),
         ('cursor', str(init)),
         ('spelling_corrections', '1'),


### PR DESCRIPTION
Fix the recurring issue of not being able to get search results using since and until config as well as the results giving us a maximum of only 20 tweets.

- url.py line 70 and 92 modified

Should help fix issues  #1281 #1288 #1295