### PR TITLE
Fix RefreshTokenException('Could not find the Guest token in HTML')

### DIFF
--- a/twint/token.py
+++ b/twint/token.py
@@ -9,11 +9,11 @@ class TokenExpiryException(Exception):
     def __init__(self, msg):
         super().__init__(msg)
 
-        
+
 class RefreshTokenException(Exception):
     def __init__(self, msg):
         super().__init__(msg)
-        
+
 
 class Token:
     def __init__(self, config):
@@ -88,7 +88,8 @@ class Token:
             res = self._session.send(req, allow_redirects=True, timeout=self._timeout)
             match = re.search(r'{"guest_token":"(\d+)"}', res.text)
             if match:
+                logme.debug('Found guest token in JSON')
                 self.config.Guest_token = str(match.group(1))
             else:
                 self.config.Guest_token = None
-                raise RefreshTokenException('Could not find the Guest token in HTML')
+                raise RefreshTokenException('Could not find the Guest token in JSON')


### PR DESCRIPTION
## About the problem

This problem has recently begun to occur on some environments.
This doesn't happen every time, so if you are lucky, you don't get the error.

The cause is literally that twint could not find the Guest token in HTML.
Actually, sometimes token isn't included in HTML recently.

```python3
#!/usr/bin/env python3
# This program is WTFPL.
import requests
res = requests.get('https://twitter.com')
print(res.text.split('\n')[-1])
```

twint require the result of running the above code is `})();</script><script nonce="VALUE">document.cookie = decodeURIComponent("gt=VALUE; Max-Age=VALUE; Domain=.twitter.com; Path=/; Secure");</script>`.
However, sometimes the result is only `})();</script>` and missing the
Guest token.

## About the solution

In this patch, twint get the Guest token from https://api.twitter.com/1.1/guest/activate.json if could not find the one.
The author referred to the code of [gallery-dl](https://github.com/mikf/gallery-dl/blob/47eae4c393f09937a5dbcc2cb978702fb173e747/gallery_dl/extractor/twitter.py#L780-L783).

Author's note:

> I don't understand session of requests, so the code may be not good.
> I hope someone rewrite the patch better and create a pull request.

This commit was adopted from https://github.com/twintproject/twint/issues/1320#issuecomment-1003094346 by @minamotorin.

Closes https://github.com/twintproject/twint/issues/1320.