### PR TITLE
Update aiohttp==3.7.0 - fixes #1297

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp
+aiohttp==3.7.0
 aiodns
 beautifulsoup4
 cchardet


### PR DESCRIPTION
## This PR contains

- Updates `requirements.txt` with `aiohttp==3.7.0` - fixes an error with:  `cannot import name 'CeilTimeout' from 'aiohttp.helpers'`

Fixes #1297 